### PR TITLE
fixed jsx highlight for .js files

### DIFF
--- a/themes/Dark Purple - Webstorm-color-theme.json
+++ b/themes/Dark Purple - Webstorm-color-theme.json
@@ -1014,15 +1014,15 @@
 			}
 		},
 		{
-			"name": "support.class.component.js.js",
-			"scope": ["support.class.component.js.js", "entity.name.tag.js.js"],
+			"name": "support.class.component.js",
+			"scope": ["support.class.component.js", "entity.name.tag.js"],
 			"settings": {
 				"foreground": "#C7A65D"
 			}
 		},
 		{
-			"name": "meta.js.children.js.js",
-			"scope": ["meta.js.children.js.js"],
+			"name": "meta.js.children.js",
+			"scope": ["meta.js.children.js"],
 			"settings": {
 				"foreground": "#d4d4d4"
 			}


### PR DESCRIPTION
This is a fix for my previous pull request (https://github.com/rexebin/darkpurple/pull/1). I've realized that my previous changes weren't working.